### PR TITLE
docs: Translate backend and frontend READMEs to Vietnamese

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,148 @@
+# Backend - Nền tảng Thương mại Điện tử
+
+## Tổng quan Dự án
+
+Thư mục này chứa các dịch vụ backend cho Nền tảng Thương mại Điện tử. Đây là một ứng dụng Node.js được xây dựng bằng framework Express.js và sử dụng cơ sở dữ liệu PostgreSQL. Backend cung cấp các RESTful API để hỗ trợ tất cả các chức năng của web client (giao diện người dùng) và admin panel (trang quản trị).
+
+## Trạng thái Hiện tại (Tiến độ V1)
+
+Backend đã triển khai thành công một phần đáng kể các yêu cầu cốt lõi của V1:
+*   **Xác thực Người dùng:** Các API mạnh mẽ cho việc đăng ký người dùng, đăng nhập (sử dụng JWT) và phân quyền dựa trên vai trò (người dùng/quản trị viên) đã sẵn sàng.
+*   **Quản lý Sản phẩm:** Các API CRUD (Tạo, Đọc, Cập nhật, Xóa) đầy đủ cho sản phẩm đã có và được bảo vệ cho người dùng quản trị. Các API công khai để liệt kê và xem sản phẩm cũng đã được triển khai.
+*   **Quản lý Giỏ hàng:** Các API để quản lý giỏ hàng của người dùng (thêm, xem, cập nhật sản phẩm, xóa giỏ hàng) đang hoạt động.
+*   **Xử lý Đơn hàng:** Các API cơ bản để tạo đơn hàng (từ giỏ hàng), xem các đơn hàng cụ thể của người dùng và truy xuất đơn hàng cấp quản trị cũng như cập nhật trạng thái đơn hàng đã được triển khai.
+*   **Tài liệu API:** Swagger UI được tích hợp để cung cấp tài liệu API tương tác.
+
+Một số tính năng backend của V1 vẫn đang chờ xử lý, được trình bày chi tiết trong Lộ trình Phát triển.
+
+## Hướng dẫn Cài đặt
+
+Để khởi chạy máy chủ backend, hãy làm theo các bước sau:
+
+1.  **Điều hướng đến Thư mục Backend:**
+    ```bash
+    cd backend
+    ```
+
+2.  **Cài đặt Dependencies:**
+    ```bash
+    npm install
+    ```
+
+3.  **Cấu hình Biến Môi trường:**
+    *   Tạo một tệp `.env` bằng cách sao chép tệp ví dụ:
+        ```bash
+        cp .env.example .env
+        ```
+    *   Mở tệp `.env` và cập nhật nó với thông tin xác thực cơ sở dữ liệu PostgreSQL thực tế của bạn (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`), một `JWT_SECRET` an toàn để tạo token và `PORT` mong muốn cho máy chủ.
+
+4.  **Cài đặt Cơ sở dữ liệu:**
+    *   Đảm bảo bạn có một máy chủ PostgreSQL đang chạy và có thể truy cập bằng thông tin xác thực bạn đã cung cấp trong tệp `.env`.
+    *   Lược đồ cơ sở dữ liệu (định nghĩa bảng) nằm ở `src/database/schema.sql`. Bạn sẽ cần thực thi tập lệnh SQL này trên cơ sở dữ liệu PostgreSQL của mình để tạo các bảng và hàm cần thiết. Đây hiện là một bước thủ công. Các cải tiến trong tương lai có thể bao gồm một hệ thống migration.
+
+5.  **Khởi động Máy chủ Backend:**
+    ```bash
+    npm start
+    ```
+    Lệnh này chạy `node src/app.js`. Máy chủ thường sẽ khởi động trên `PORT` được định nghĩa trong tệp `.env` của bạn (mặc định là 3001).
+
+## Tài liệu API
+
+Tài liệu API tương tác sử dụng Swagger UI có sẵn khi máy chủ backend đang chạy. Bạn có thể truy cập nó tại điểm cuối `/api-docs` (ví dụ: `http://localhost:3001/api-docs`).
+Cấu hình Swagger (`src/config/swagger.config.js`) bao gồm các lược đồ chi tiết cho các yêu cầu và phản hồi.
+
+## Lược đồ Cơ sở dữ liệu
+
+Backend sử dụng cơ sở dữ liệu PostgreSQL. Lược đồ được định nghĩa trong `src/database/schema.sql`.
+
+**Các Bảng Chính:**
+
+*   **`users`**: Lưu trữ thông tin người dùng, bao gồm thông tin đăng nhập (mật khẩu đã băm) và vai trò (ví dụ: 'user', 'admin').
+*   **`categories`**: Lưu trữ các danh mục sản phẩm để giúp tổ chức sản phẩm.
+*   **`products`**: Chứa thông tin chi tiết về sản phẩm, như tên, mô tả, giá, số lượng tồn kho và liên kết danh mục.
+*   **`carts`**: Đại diện cho giỏ hàng của người dùng, liên kết với người dùng. Mỗi người dùng có một giỏ hàng duy nhất.
+*   **`cart_items`**: Lưu trữ các mặt hàng trong giỏ hàng của người dùng, bao gồm ID sản phẩm, số lượng và giá tại thời điểm thêm vào.
+*   **`orders`**: Chứa thông tin về đơn đặt hàng của khách hàng, như ID người dùng, tổng số tiền, địa chỉ giao hàng, chi tiết thanh toán và trạng thái đơn hàng.
+*   **`order_items`**: Chi tiết các sản phẩm cụ thể, số lượng và giá cho mỗi mặt hàng trong một đơn hàng.
+
+**Tự động hóa Timestamp:**
+
+*   Một hàm PL/pgSQL, `trigger_set_timestamp()`, được sử dụng.
+*   Các trigger được áp dụng cho tất cả các bảng chính để tự động cập nhật cột `updated_at` thành timestamp hiện tại mỗi khi một hàng được sửa đổi.
+
+## Lộ trình Phát triển
+
+Lộ trình này phác thảo các tính năng và cải tiến đã được lên kế hoạch, phần lớn dựa trên README chính của dự án.
+
+### Phiên bản 1 (V1) - Nền tảng Thương mại Điện tử Cốt lõi (Tập trung Thị trường Nội địa)
+
+#### Đã hoàn thành/Hiện tại:
+*   Hệ thống xác thực người dùng (đăng ký, đăng nhập, JWT, vai trò).
+*   API quản lý sản phẩm (CRUD cho quản trị viên, quyền đọc công khai).
+*   API quản lý giỏ hàng cơ bản (thêm, xem, cập nhật, xóa sản phẩm).
+*   API tạo và truy xuất đơn hàng cơ bản (quyền truy cập của người dùng cụ thể và quản trị viên).
+*   API quản trị để quản lý chi tiết sản phẩm và trạng thái đơn hàng.
+*   Theo dõi hàng tồn kho cơ bản (trường số lượng tồn kho trên sản phẩm).
+
+#### Chờ xử lý/Cần làm (Công việc backend cho V1):
+*   **Quản lý Hồ sơ Người dùng:**
+    *   API cho người dùng quản lý thông tin cá nhân của họ (ví dụ: cập nhật tên, mật khẩu).
+    *   API để quản lý địa chỉ người dùng (chức năng sổ địa chỉ).
+*   **Cải tiến Đơn hàng:**
+    *   API cho lịch sử đơn hàng chi tiết hơn và theo dõi trạng thái chi tiết hiển thị cho người dùng.
+*   **Trang tổng quan Quản trị & Tính năng:**
+    *   API cung cấp số liệu thống kê cho trang tổng quan quản trị (ví dụ: doanh số, người dùng mới, sản phẩm phổ biến).
+    *   API cho quản trị viên quản lý danh mục sản phẩm (CRUD cho danh mục).
+*   **Phương thức Thanh toán:**
+    *   Tinh chỉnh logic xử lý đơn hàng COD.
+    *   API hỗ trợ và quản lý thông tin cho các phương thức thanh toán V1 khác (ví dụ: chi tiết chuyển khoản ngân hàng, có thể có API quản trị để cấu hình).
+    *   Cơ chế cho quản trị viên xác nhận thanh toán thủ công.
+*   **Thông báo:**
+    *   Triển khai hệ thống thông báo qua email cho các sự kiện như xác nhận đơn hàng và cập nhật trạng thái.
+*   **Quản lý Nội dung:**
+    *   (Nếu nội dung tĩnh như "Giới thiệu", "Chính sách" được quản lý bởi quản trị viên) Các điểm cuối API để truy xuất/cập nhật nội dung của các trang thông tin.
+*   **Hàng tồn kho & Giảm giá:**
+    *   Tinh chỉnh logic cập nhật hàng tồn kho trong quá trình đặt hàng để tránh bán quá số lượng.
+    *   (Nếu có cho V1) API để tạo và xác thực mã giảm giá cơ bản.
+*   **Cải tiến Vận hành:**
+    *   Nâng cao và chuẩn hóa xử lý lỗi trên tất cả các điểm cuối API.
+    *   Cải thiện ghi log để gỡ lỗi và giám sát.
+
+### Phiên bản 2 (V2) - Cải tiến và Cân nhắc Ban đầu cho Thị trường "Ngoài Nước"
+
+*   **Quốc tế hóa:**
+    *   API hỗ trợ thông tin sản phẩm đa ngôn ngữ (tên, mô tả).
+    *   API xử lý hiển thị và xử lý đa tiền tệ (chuyển đổi giá, tùy chọn tiền tệ của người dùng).
+*   **Mở rộng Thanh toán:**
+    *   Tích hợp với các cổng thanh toán quốc tế (ví dụ: Stripe, PayPal).
+*   **Trải nghiệm Người dùng & Tính năng:**
+    *   API hỗ trợ lọc sản phẩm nâng cao (ví dụ: theo thuộc tính, xếp hạng) và cải thiện khả năng tìm kiếm.
+    *   API cho hệ thống đánh giá và xếp hạng của khách hàng.
+    *   API hỗ trợ chức năng danh sách yêu thích (wishlist).
+*   **Cải tiến Trang quản trị:**
+    *   API quản lý khách hàng cơ bản (xem danh sách khách hàng, có thể có giao tiếp).
+    *   API phân tích và báo cáo chi tiết hơn cho quản trị viên.
+    *   API quản lý nội dung trang chủ (banner, sản phẩm nổi bật) nếu chưa thực hiện trong V1.
+*   **Thương mại Xã hội (Social Commerce):**
+    *   Hỗ trợ backend/API nếu bất kỳ tính năng thương mại xã hội nào yêu cầu logic phía máy chủ (ví dụ: nguồn cấp dữ liệu sản phẩm).
+
+### Phiên bản 3 (V3) - Tính năng Nâng cao và Khả năng Mở rộng
+
+*   **Phân tích & Cá nhân hóa Nâng cao:**
+    *   API cho phân tích và báo cáo toàn diện.
+    *   Backend cho một công cụ cá nhân hóa (ví dụ: đề xuất sản phẩm dựa trên hành vi người dùng).
+*   **Khả năng Mở rộng & Hiệu suất:**
+    *   Điều tra và triển khai các cải tiến về khả năng mở rộng (ví dụ: tối ưu hóa cơ sở dữ liệu, chiến lược bộ nhớ đệm, tiềm năng cho microservices cho các chức năng cụ thể).
+*   **Logistics & Tích hợp:**
+    *   API để tích hợp sâu hơn với các nhà cung cấp dịch vụ logistics và vận chuyển tiên tiến.
+*   **Tính năng dựa trên AI:**
+    *   Hỗ trợ backend cho các tính năng dựa trên AI (ví dụ: tìm kiếm dựa trên AI, chatbot dịch vụ khách hàng).
+*   **Chức năng Thị trường (Marketplace):**
+    *   (Nếu có kế hoạch) API hỗ trợ nhiều nhà cung cấp, sản phẩm theo nhà cung cấp và cấu trúc hoa hồng.
+
+## Cách Đóng góp
+
+Thông tin chi tiết về việc đóng góp vào phát triển backend, bao gồm các tiêu chuẩn mã hóa, quản lý nhánh và quy trình pull request, sẽ được thêm vào đây. Chúng tôi khuyến khích các đóng góp phù hợp với lộ trình phát triển và nâng cao sự ổn định cũng như bộ tính năng của nền tảng.
+
+---
+*README này là một tài liệu sống và sẽ được cập nhật khi dự án tiến triển.*

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,122 @@
-# React + Vite
+# Frontend - Nền tảng Thương mại Điện tử
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## Tổng quan Dự án
 
-Currently, two official plugins are available:
+Thư mục này chứa ứng dụng frontend cho Nền tảng Thương mại Điện tử. Đây là một ứng dụng trang đơn (SPA) được xây dựng bằng React và Vite, sử dụng Tailwind CSS để tạo kiểu. Frontend tương tác với các API backend để cung cấp giao diện người dùng cho khách hàng và quản trị viên.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Trạng thái Hiện tại (Tiến độ V1)
 
-## Expanding the ESLint configuration
+Frontend đã triển khai một số tính năng V1 quan trọng:
+*   **Xác thực Người dùng:** Các trang đăng ký và đăng nhập người dùng, với trạng thái xác thực được quản lý thông qua `AuthContext.jsx`.
+*   **Duyệt Sản phẩm:**
+    *   `ProductsPage.jsx` để liệt kê tất cả sản phẩm.
+    *   `ProductDetailPage.jsx` được liên kết và có sẵn để xem chi tiết sản phẩm.
+*   **Giỏ hàng:** `CartPage.jsx` với chức năng xem, thêm, cập nhật số lượng và xóa sản phẩm, được quản lý thông qua `CartContext.jsx`.
+*   **Trang tổng quan Người dùng:** Một `DashboardPage.jsx` cơ bản tồn tại, dành cho người dùng xem lịch sử đơn hàng của họ.
+*   **Trang Quản trị (Admin Panel):** Một khu vực quản trị riêng (`/admin`) với:
+    *   Giao diện quản lý sản phẩm (`AdminProductsPage.jsx`, `AdminAddProductPage.jsx`, `AdminEditProductPage.jsx`).
+    *   Giao diện xem và quản lý đơn hàng cơ bản (`AdminOrdersPage.jsx`, `AdminOrderDetailPage.jsx`).
+*   **Định tuyến (Routing):** Định tuyến an toàn và dựa trên vai trò sử dụng `react-router-dom`, `ProtectedRoute.jsx`, và `AdminRoute.jsx`.
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Nhiều tính năng frontend V1 vẫn đang được phát triển hoặc chờ xử lý, được trình bày chi tiết trong Lộ trình Phát triển.
+
+## Hướng dẫn Cài đặt
+
+Để cài đặt và chạy máy chủ phát triển frontend:
+
+1.  **Điều hướng đến Thư mục Frontend:**
+    ```bash
+    cd frontend
+    ```
+
+2.  **Cài đặt Dependencies:**
+    ```bash
+    npm install
+    ```
+
+3.  **Biến Môi trường:**
+    *   Tạo một tệp `.env` trong thư mục `frontend` nếu nó không tồn tại. Bạn có thể sao chép một ví dụ nếu có hoặc tạo thủ công.
+    *   Một biến môi trường phổ biến bạn có thể cần là URL cơ sở cho API backend:
+        ```env
+        VITE_API_BASE_URL=http://localhost:3001/api
+        ```
+        Thay thế `http://localhost:3001/api` bằng URL thực tế nếu máy chủ backend của bạn chạy ở nơi khác. Vite sử dụng tiền tố `VITE_` cho các biến môi trường được exposé cho mã phía client.
+
+4.  **Khởi động Máy chủ Phát triển:**
+    ```bash
+    npm run dev
+    ```
+    Lệnh này sẽ khởi động máy chủ phát triển Vite, thường có sẵn tại `http://localhost:5173` (hoặc một cổng khác nếu 5173 đang bận).
+
+## Cấu trúc Dự án
+
+Thư mục `src/` chứa mã nguồn cốt lõi cho ứng dụng React:
+
+*   **`pages/`**: Chứa các thành phần cấp cao nhất đại diện cho các chế độ xem hoặc trang khác nhau có thể truy cập thông qua các tuyến đường (ví dụ: `HomePage.jsx`, `ProductsPage.jsx`, `admin/AdminDashboardPage.jsx`).
+*   **`components/`**: Chứa các thành phần UI có thể tái sử dụng được sử dụng trên nhiều trang hoặc trong các thành phần khác. Điều này bao gồm các thành phần chuyên biệt như `AdminRoute.jsx` để truy cập chỉ dành cho quản trị viên và `ProtectedRoute.jsx` để truy cập người dùng đã xác thực.
+*   **`layouts/`**: Chứa các thành phần cấu trúc xác định bố cục tổng thể cho các phần khác nhau của ứng dụng (ví dụ: `AdminLayout.jsx` cung cấp cấu trúc thanh bên và nội dung chính cho trang quản trị).
+*   **`contexts/`**: Triển khai API Context của React để quản lý trạng thái toàn cục. Các context chính bao gồm `AuthContext.jsx` (cho xác thực và dữ liệu người dùng) và `CartContext.jsx` (cho trạng thái và hoạt động của giỏ hàng).
+*   **`services/`**: Các module chịu trách nhiệm thực hiện các lệnh gọi API đến backend. Điều này bao gồm một `api.js` chung (thường là một thiết lập instance Axios) và các tệp dịch vụ cụ thể như `productService.js`, `cartService.js`, và `orderService.js`.
+*   **`assets/`**: Lưu trữ các tài sản tĩnh như hình ảnh, SVG và các stylesheet toàn cục.
+
+## Lộ trình Phát triển
+
+Lộ trình này phác thảo các tính năng và cải tiến đã được lên kế hoạch cho frontend, dựa trên README chính của dự án.
+
+### Phiên bản 1 (V1) - Nền tảng Thương mại Điện tử Cốt lõi (Tập trung Thị trường Nội địa)
+
+#### Đã hoàn thành/Hiện tại:
+*   Các trang đăng ký (`RegisterPage.jsx`) và đăng nhập (`LoginPage.jsx`) người dùng.
+*   Trang danh sách sản phẩm (`ProductsPage.jsx`) và trang chi tiết sản phẩm (`ProductDetailPage.jsx`).
+*   Chức năng giỏ hàng cơ bản (`CartPage.jsx`, `CartContext.jsx`).
+*   Trang tổng quan người dùng cơ bản (`DashboardPage.jsx`) để xem đơn hàng.
+*   Các mục trong trang quản trị để xem/quản lý cơ bản sản phẩm và đơn hàng.
+*   Các tuyến đường được bảo vệ cho các mục yêu cầu xác thực người dùng và các mục chỉ dành cho quản trị viên.
+
+#### Chờ xử lý/Cần làm (Công việc frontend cho V1 từ README chính):
+*   **Trang chủ Động:** Triển khai một trang chủ động với các yếu tố như banner/slider, sản phẩm nổi bật và liên kết danh mục (có thể lấy cảm hứng từ các mockup `GIAO DIENJ 3D` hoặc các thông lệ thương mại điện tử chung).
+*   **Danh sách Sản phẩm Nâng cao:**
+    *   Triển khai khả năng lọc (ví dụ: theo danh mục, khoảng giá, thương hiệu).
+    *   Thêm tùy chọn sắp xếp (ví dụ: theo giá, mức độ phổ biến, mới nhất).
+*   **Tìm kiếm Sản phẩm:** Tích hợp thanh tìm kiếm sản phẩm chức năng và hiển thị kết quả.
+*   **Quản lý Hồ sơ Người dùng:** Tạo một trang cho người dùng quản lý thông tin cá nhân (tên, mật khẩu) và địa chỉ giao hàng (sổ địa chỉ).
+*   **Lịch sử Đơn hàng Chi tiết:** Nâng cao trang tổng quan người dùng để hiển thị lịch sử đơn hàng chi tiết với theo dõi trạng thái cho mỗi đơn hàng.
+*   **Quy trình Thanh toán Đầy đủ Chức năng:**
+    *   Phát triển `CheckoutPage.jsx` với các biểu mẫu thông tin giao hàng.
+    *   Triển khai giao diện người dùng để chọn phương thức vận chuyển (nếu có).
+    *   Cung cấp giao diện người dùng để chọn phương thức thanh toán (COD và hiển thị chi tiết Chuyển khoản Ngân hàng theo mục tiêu V1).
+    *   Tóm tắt đơn hàng rõ ràng trước khi xác nhận cuối cùng.
+*   **Trang Xác nhận Đơn hàng:** Thiết kế và triển khai `OrderConfirmationPage.jsx` thân thiện với người dùng, tóm tắt đơn hàng đã đặt.
+*   **Các Trang Thông tin:** Tạo các thành phần/trang cho "Giới thiệu," "Chính sách Đổi trả," "Chính sách Bảo mật," và "Liên hệ." Nội dung ban đầu có thể là tĩnh hoặc được lấy nếu quản trị viên quản lý.
+*   **Trang tổng quan Quản trị:** Điền dữ liệu thực tế (cơ bản) vào `AdminDashboardPage.jsx` được lấy từ backend.
+*   **Giao diện Quản trị để quản lý danh mục:** Phát triển giao diện người dùng cho quản trị viên thêm, xem, chỉnh sửa và xóa danh mục sản phẩm.
+*   **(Nếu có) Giao diện người dùng để áp dụng mã giảm giá:** Thêm các yếu tố giao diện người dùng trong giỏ hàng hoặc thanh toán để áp dụng mã giảm giá, nếu được backend hỗ trợ cho V1.
+*   **Giao diện người dùng cho đánh giá và xếp hạng sản phẩm:** Triển khai giao diện người dùng để hiển thị đánh giá sản phẩm và cho phép người dùng gửi xếp hạng và nhận xét trên các trang chi tiết sản phẩm.
+*   **Đảm bảo khả năng đáp ứng đầy đủ (Ưu tiên thiết bị di động):** Xác minh và nâng cao khả năng đáp ứng trên tất cả các trang và thành phần.
+
+### Phiên bản 2 (V2) - Cải tiến và Cân nhắc Ban đầu cho Thị trường "Ngoài Nước"
+(Tham khảo README chính cho các tác vụ frontend)
+*   **Hỗ trợ đa ngôn ngữ trong giao diện người dùng:** Tích hợp thư viện i18n (ví dụ: `react-i18next`) và cung cấp các yếu tố giao diện người dùng để chọn ngôn ngữ.
+*   **Các yếu tố giao diện người dùng để chọn/hiển thị tiền tệ:** Đảm bảo giá được hiển thị bằng đơn vị tiền tệ ưa thích của người dùng hoặc phù hợp với khu vực.
+*   **Frontend cho tích hợp cổng thanh toán quốc tế mới:** Phát triển các thành phần cho bất kỳ cổng thanh toán mới nào nếu chúng yêu cầu các yếu tố giao diện người dùng cụ thể.
+*   **Giao diện người dùng cho hệ thống đánh giá và xếp hạng của khách hàng:** Nâng cao giao diện hiển thị và gửi đánh giá.
+*   **Giao diện Trang quản trị Nâng cao:**
+    *   Giao diện người dùng cho các tính năng quản lý khách hàng.
+    *   Giao diện người dùng để quản lý nội dung (banner, trang động) nếu được quản trị viên chỉnh sửa.
+    *   Giao diện người dùng cho phân tích chi tiết hơn.
+*   **Giao diện người dùng cho tích hợp thương mại xã hội:** Triển khai các tùy chọn đăng nhập xã hội (Google/Facebook) và các nút chia sẻ xã hội.
+*   **Trang danh sách yêu thích và chức năng thêm vào danh sách yêu thích:** Tạo giao diện người dùng để người dùng quản lý danh sách yêu thích và thêm sản phẩm vào đó.
+
+### Phiên bản 3 (V3) - Tính năng Nâng cao và Khả năng Mở rộng
+(Tham khảo README chính cho các tác vụ frontend)
+*   **Giao diện người dùng cho phân tích và báo cáo nâng cao:** Phát triển các thành phần giao diện người dùng phức tạp để hiển thị dữ liệu nâng cao cho quản trị viên.
+*   **Giao diện người dùng cho đề xuất sản phẩm được cá nhân hóa:** Tạo các yếu tố frontend để hiển thị nội dung được cá nhân hóa.
+*   **Giao diện người dùng để theo dõi logistics/vận chuyển nâng cao:** Nâng cao giao diện người dùng để theo dõi lô hàng chi tiết nếu backend hỗ trợ.
+*   **(Nếu có) Giao diện người dùng cho các tính năng dựa trên AI:** Tích hợp giao diện người dùng cho các tính năng như chatbot dịch vụ khách hàng.
+*   **(Nếu có) Giao diện người dùng cho các tính năng thị trường:** Phát triển giao diện người dùng cho trang tổng quan của nhà cung cấp, biểu mẫu gửi sản phẩm, v.v., nếu nền tảng phát triển thành một thị trường.
+
+## Cách Đóng góp
+Thông tin chi tiết về việc đóng góp, tiêu chuẩn mã hóa và quy trình pull request sẽ được thêm vào đây.
+
+---
+*README này là một tài liệu sống và sẽ được cập nhật khi dự án tiến triển.*


### PR DESCRIPTION
I've updated the README.md files in the /backend and /frontend directories with Vietnamese translations of their content.

This addresses your request to have the detailed developer guides available in Vietnamese. The structure and technical information remain consistent with the previous English versions.